### PR TITLE
Object to query string

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
                         <a href="#object-manipulation" class="has-submenu">Object Manipulation <i class="fas fa-chevron-down"></i></a>
                         <ul>
                             <li><a href="#removeEmptyKeysEntries">removeEmptyKeysEntries</a></li>
+                            <li><a href="#objectToQueryString">objectToQueryString</a></li>
                         </ul>
                     </li>
                     <li>
@@ -854,6 +855,34 @@ implode(["Hello", "World"], ", ") // "Hello, World"
 removeEmptyKeysEntries({ a: 1, b: null })          // { a: 1 }
 removeEmptyKeysEntries({ a: 1, b: '' })            // { a: 1 }
 removeEmptyKeysEntries({ a: 1, b: 2 })             // { a: 1, b: 2 }</code></pre>
+            </section>
+            <section id="objectToQueryString">
+                <h3>objectToQueryString</h3>
+                <p>Converts an object, array of key-value pairs (matrix), or a flat array of alternating keys and values into a URL query string. <br>
+                   The function can handle different input formats: <br>
+                    - A plain object (Record &lt;string, any&gt;), <br>
+                    - A matrix (an array of arrays, where each sub-array has two elements representing a key-value pair), <br>
+                    - A flat array with an even number of elements, where each even-indexed element is a key, and the following odd-indexed element is its corresponding value.</p>
+                <pre><code class="language-typescript">// Using a plain object
+objectToQueryString({ key1: 'value1', key2: 'value2' });
+// Returns: "key1=value1&key2=value2"
+        
+// Using a matrix (array of key-value pairs)
+objectToQueryString([['key1', 'value1'], ['key2', 'value2']]);
+// Returns: "key1=value1&key2=value2"
+
+// Using a flat array
+objectToQueryString(['key1', 'value1', 'key2', 'value2']);
+// Returns: "key1=value1&key2=value2"
+
+// Throws an error for an invalid array format
+objectToQueryString([['key1', 'value1'], 'invalid']);
+// Throws: Error: Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements.
+
+// Throws an error for an empty object / array
+objectToQueryString([]);
+objectToQueryString({});
+// throw new Error("Invalid input format: Expected a non-empty object or a valid array format.");</code></pre>
             </section>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -882,7 +882,7 @@ objectToQueryString([['key1', 'value1'], 'invalid']);
 // Throws an error for an empty object / array
 objectToQueryString([]);
 objectToQueryString({});
-// throw new Error("Invalid input format: Expected a non-empty object or a valid array format.");</code></pre>
+// Throws: Error: Invalid input format: Expected a non-empty object or a valid array format.</code></pre>
             </section>
         </section>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camote-utils",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A comprehensive TypeScript utility library featuring advanced string and number formatting, data structures, and algorithms",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/chain/index.ts
+++ b/src/chain/index.ts
@@ -98,6 +98,11 @@ export class _ {
         return this
     }
 
+    public objectToQueryString(): this {
+        this.value = objectFormatters.objectToQueryString(this.value);
+        return this
+    }
+
     // String operations
     capitalize(): _ {
         this.value = stringFormatters.capitalize(String(this.value))

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -67,7 +67,7 @@ export const removeEmptyKeysEntries = (
  * // Throws an error for an empty object / array
  * objectToQueryString([]);
  * objectToQueryString({});
- * // throw new Error("Invalid input format: Expected a non-empty object or a valid array format.");
+ * // Throws: Error: Invalid input format: Expected a non-empty object or a valid array format.
  */
 
 export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>> | Array<any>): string => {

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -27,49 +27,6 @@ export const removeEmptyKeysEntries = (
   )
 }
 
-/**
- * Converts an object, array of key-value pairs (matrix), or a flat array of alternating keys and values into a URL query string.
- * The function can handle different input formats:
- * - A plain object (Record<string, any>),
- * - A matrix (an array of arrays, where each sub-array has two elements representing a key-value pair),
- * - A flat array with an even number of elements, where each even-indexed element is a key, and the following odd-indexed element is its corresponding value.
- * 
- * The function throws an error if the input is invalid, such as a malformed array or empty object.
- * 
- * @param {Record<string, any> | Array<Array<any>> | Array<any>} obj - The input to be converted into a query string. This can be:
- *    - A plain object (e.g., `{ key1: 'value1', key2: 'value2' }`),
- *    - An array of key-value pairs (e.g., `[ ['key1', 'value1'], ['key2', 'value2'] ]`),
- *    - A flat array (e.g., `['key1', 'value1', 'key2', 'value2']`).
- * 
- * @returns {string} The resulting query string in the form of `key1=value1&key2=value2`.
- * 
- * @throws {Error} Throws an error if the input format is invalid:
- *    - If the array format is incorrect (e.g., an array that is not a matrix or a flat array with an even number of elements),
- *    - If the object is empty or null.
- * 
- * @example
- * // Using a plain object
- * objectToQueryString({ key1: 'value1', key2: 'value2' });
- * // Returns: "key1=value1&key2=value2"
- * 
- * // Using a matrix (array of key-value pairs)
- * objectToQueryString([['key1', 'value1'], ['key2', 'value2']]);
- * // Returns: "key1=value1&key2=value2"
- * 
- * // Using a flat array
- * objectToQueryString(['key1', 'value1', 'key2', 'value2']);
- * // Returns: "key1=value1&key2=value2"
- *
- * // Throws an error for an invalid array format
- * objectToQueryString([['key1', 'value1'], 'invalid']);
- * // Throws: Error: Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements.
- * 
- * // Throws an error for an empty object / array
- * objectToQueryString([]);
- * objectToQueryString({});
- * // Throws: Error: Invalid input format: Expected a non-empty object or a valid array format.
- */
-
 export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>> | Array<any>): string => {
   if (Array.isArray(obj) && obj.length > 0) {
    const isMatrix = obj.every(item => Array.isArray(item) && item.length == 2);

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -66,21 +66,18 @@ export const removeEmptyKeysEntries = (
  */
 
 export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>> | Array<any>): string => {
-  if (Array.isArray(obj)) {
+  if (Array.isArray(obj) && obj.length > 0) {
    const isMatrix = obj.every(item => Array.isArray(item) && item.length == 2);
    if (isMatrix) {
      return new URLSearchParams(obj).toString();
    }
 
-   const isFlatArray = obj.every(item => typeof item !== "object");
+   const isFlatArray = obj.every(item => typeof item !== "object") && obj.length % 2 == 0;
    if (isFlatArray) {
      //const newObj = Array.from({length: Math.ceil(obj.length / 2)}, (v, i) => obj.slice(i * 2, i * 2 + 2 )).filter(x => x.length == 2);
      const newObj = obj.reduce((acc, curr, idx, array) => {
        if (idx % 2 == 0) {
-         const value = array[idx + 1] !== undefined;
-         if (value) {
-           acc[curr] = value;
-         }
+          acc[curr] = array[idx + 1];
        }
        return acc;
      }, {} as Record<string, any>);

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -26,3 +26,76 @@ export const removeEmptyKeysEntries = (
       .filter(([_, value]) => value !== null && value !== undefined)
   )
 }
+
+/**
+ * Converts an object, array of key-value pairs (matrix), or a flat array of alternating keys and values into a URL query string.
+ * The function can handle different input formats:
+ * - A plain object (Record<string, any>),
+ * - A matrix (an array of arrays, where each sub-array has two elements representing a key-value pair),
+ * - A flat array with an even number of elements, where each even-indexed element is a key, and the following odd-indexed element is its corresponding value.
+ * 
+ * The function throws an error if the input is invalid, such as a malformed array or empty object.
+ * 
+ * @param {Record<string, any> | Array<Array<any>> | Array<any>} obj - The input to be converted into a query string. This can be:
+ *    - A plain object (e.g., `{ key1: 'value1', key2: 'value2' }`),
+ *    - An array of key-value pairs (e.g., `[ ['key1', 'value1'], ['key2', 'value2'] ]`),
+ *    - A flat array (e.g., `['key1', 'value1', 'key2', 'value2']`).
+ * 
+ * @returns {string} The resulting query string in the form of `key1=value1&key2=value2`.
+ * 
+ * @throws {Error} Throws an error if the input format is invalid:
+ *    - If the array format is incorrect (e.g., an array that is not a matrix or a flat array with an even number of elements),
+ *    - If the object is empty or null.
+ * 
+ * @example
+ * // Using a plain object
+ * objectToQueryString({ key1: 'value1', key2: 'value2' });
+ * // Returns: "key1=value1&key2=value2"
+ * 
+ * // Using a matrix (array of key-value pairs)
+ * objectToQueryString([['key1', 'value1'], ['key2', 'value2']]);
+ * // Returns: "key1=value1&key2=value2"
+ * 
+ * // Using a flat array
+ * objectToQueryString(['key1', 'value1', 'key2', 'value2']);
+ * // Returns: "key1=value1&key2=value2"
+ *
+ * // Throws an error for an invalid array format
+ * objectToQueryString([['key1', 'value1'], 'invalid']);
+ * // Throws: Error: Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements.
+ */
+
+export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>> | Array<any>): string => {
+  if (Array.isArray(obj)) {
+   const isMatrix = obj.every(item => Array.isArray(item) && item.length == 2);
+   if (isMatrix) {
+     return new URLSearchParams(obj).toString();
+   }
+
+   const isFlatArray = obj.every(item => typeof item !== "object");
+   if (isFlatArray) {
+     //const newObj = Array.from({length: Math.ceil(obj.length / 2)}, (v, i) => obj.slice(i * 2, i * 2 + 2 )).filter(x => x.length == 2);
+     const newObj = obj.reduce((acc, curr, idx, array) => {
+       if (idx % 2 == 0) {
+         const value = array[idx + 1] !== undefined;
+         if (value) {
+           acc[curr] = value;
+         }
+       }
+       return acc;
+     }, {} as Record<string, any>);
+
+     return new URLSearchParams(newObj).toString();
+   }
+
+   throw new Error("Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements.");
+  }
+
+
+  if (typeof obj === "object" && obj !== null && Object.entries(obj).length > 0) {
+   return new URLSearchParams(obj).toString();
+  }
+
+
+  throw new Error("Invalid input format: Expected a non-empty object or a valid array format.");
+};

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -36,7 +36,6 @@ export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>>
 
    const isFlatArray = obj.every(item => typeof item !== "object") && obj.length % 2 == 0;
    if (isFlatArray) {
-     //const newObj = Array.from({length: Math.ceil(obj.length / 2)}, (v, i) => obj.slice(i * 2, i * 2 + 2 )).filter(x => x.length == 2);
      const newObj = obj.reduce((acc, curr, idx, array) => {
        if (idx % 2 == 0) {
           acc[curr] = array[idx + 1];

--- a/src/formatters/object.ts
+++ b/src/formatters/object.ts
@@ -63,6 +63,11 @@ export const removeEmptyKeysEntries = (
  * // Throws an error for an invalid array format
  * objectToQueryString([['key1', 'value1'], 'invalid']);
  * // Throws: Error: Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements.
+ * 
+ * // Throws an error for an empty object / array
+ * objectToQueryString([]);
+ * objectToQueryString({});
+ * // throw new Error("Invalid input format: Expected a non-empty object or a valid array format.");
  */
 
 export const objectToQueryString = (obj: Record<string, any> | Array<Array<any>> | Array<any>): string => {

--- a/tests/chain.test.ts
+++ b/tests/chain.test.ts
@@ -133,7 +133,7 @@ describe('Chain - Object Operations', () => {
       _.chain(['key1', 'value1', 'key2'])
         .objectToQueryString()
         .valueOf();
-    }).toThrow();
+    }).toThrow(new Error("Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements."));
   });
 
   it('should throw an error if an invalid nested array is passed after flattening', () => {
@@ -142,6 +142,15 @@ describe('Chain - Object Operations', () => {
         .flattenArray()
         .objectToQueryString()
         .valueOf();
-    }).toThrow();
+    }).toThrow(new Error("Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements."));
+  });
+
+  it('should throw an error if an invalid nested array is passed after flattening', () => {
+    expect(() => {
+      _.chain([[], []])
+        .flattenArray()
+        .objectToQueryString()
+        .valueOf();
+    }).toThrow(new Error("Invalid input format: Expected a non-empty object or a valid array format."));
   });
 })

--- a/tests/chain.test.ts
+++ b/tests/chain.test.ts
@@ -128,6 +128,15 @@ describe('Chain - Object Operations', () => {
     expect(result).toBe('1=2&3=4&5=6');
   });
 
+  it('should flatten an array and then convert to query string', () => {
+    const result = _.chain(['key1', 'value1', 'key2', 'value2', ['key3', 'value3']])
+      .flattenArray()
+      .objectToQueryString()
+      .valueOf();
+
+    expect(result).toBe('key1=value1&key2=value2&key3=value3')
+  });
+
   it('should throw an error for an invalid flat array format (odd number of elements)', () => {
     expect(() => {
       _.chain(['key1', 'value1', 'key2'])

--- a/tests/chain.test.ts
+++ b/tests/chain.test.ts
@@ -101,3 +101,47 @@ describe('valueOf', () => {
     expect(result).toBe('test value');
   });
 });
+
+describe('Chain - Object Operations', () => {
+  it('should convert a flat array to query string', () => {
+    const result = _.chain(['key1', 'value1', 'key2', 'value2'])
+      .objectToQueryString()
+      .valueOf();
+
+    expect(result).toBe('key1=value1&key2=value2');
+  });
+
+  it('should convert a matrix array to query string', () => {
+    const result = _.chain([['key1', 'value1'], ['key2', 'value2']])
+      .objectToQueryString()
+      .valueOf();
+
+    expect(result).toBe('key1=value1&key2=value2');
+  });
+
+  it('should remove duplicates and then convert to query string', () => {
+    const result = _.chain([1, 2, 2, 3, 4, 4, 5, 6, 6])
+      .removeDuplicates()  
+      .objectToQueryString()
+      .valueOf(); 
+
+    expect(result).toBe('1=2&3=4&5=6');
+  });
+
+  it('should throw an error for an invalid flat array format (odd number of elements)', () => {
+    expect(() => {
+      _.chain(['key1', 'value1', 'key2'])
+        .objectToQueryString()
+        .valueOf();
+    }).toThrow();
+  });
+
+  it('should throw an error if an invalid nested array is passed after flattening', () => {
+    expect(() => {
+      _.chain(['key1', 'value1', 'key2', 'value2', ['key3']])
+        .flattenArray()
+        .objectToQueryString()
+        .valueOf();
+    }).toThrow();
+  });
+})

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -1,4 +1,4 @@
-import { removeEmptyKeysEntries } from './../src/formatters/object';
+import { removeEmptyKeysEntries, objectToQueryString } from './../src/formatters/object';
 
 describe('removeEmptyKeysEntries', () => {
   it('should remove keys with falsy values', () => {
@@ -50,5 +50,51 @@ describe('removeEmptyKeysEntries', () => {
     const transformFn = (value: number) => value * 2;
     const expectedOutput = { a: [2, 4, 6], b: ['hello', 'world'] };
     expect(removeEmptyKeysEntries(input, transformFn)).toEqual(expectedOutput);
+  });
+});
+
+
+describe('objectToQueryString', () => {
+  
+  // Test valid cases
+
+  it('should convert a plain object to a query string', () => {
+    const input = { key1: 'value1', key2: 'value2' };
+    const result = objectToQueryString(input);
+    expect(result).toBe('key1=value1&key2=value2');
+  });
+
+  it('should convert a matrix array to a query string', () => {
+    const input = [['key1', 'value1'], ['key2', 'value2']];
+    const result = objectToQueryString(input);
+    expect(result).toBe('key1=value1&key2=value2');
+  });
+
+  it('should convert a flat array with key-value pairs to a query string', () => {
+    const input = ['key1', 'value1', 'key2', 'value2'];
+    const result = objectToQueryString(input);
+    expect(result).toBe('key1=value1&key2=value2');
+  });
+
+  // Test invalid cases
+
+  it('should throw an error for an invalid matrix format', () => {
+    const input = [['key1', 'value1'], 'invalid'];
+    expect(() => objectToQueryString(input)).toThrow();
+  });
+
+  it('should throw an error for a flat array with an odd number of elements', () => {
+    const input = ['key1', 'value1', 'key2'];
+    expect(() => objectToQueryString(input)).toThrow();
+  });
+
+  it('should throw an error for an empty object', () => {
+    const input = {};
+    expect(() => objectToQueryString(input)).toThrow();
+  });
+
+  it('should throw an error for an empty array', () => {
+    const input: any[] = [];
+    expect(() => objectToQueryString(input)).toThrow();
   });
 });

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -80,21 +80,21 @@ describe('objectToQueryString', () => {
 
   it('should throw an error for an invalid matrix format', () => {
     const input = [['key1', 'value1'], 'invalid'];
-    expect(() => objectToQueryString(input)).toThrow();
+    expect(() => objectToQueryString(input)).toThrow(new Error("Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements."));
   });
 
   it('should throw an error for a flat array with an odd number of elements', () => {
     const input = ['key1', 'value1', 'key2'];
-    expect(() => objectToQueryString(input)).toThrow();
+    expect(() => objectToQueryString(input)).toThrow(new Error("Invalid array format: Expected either an array of key-value pairs (matrix) or a flat array with an even number of elements."));
   });
 
   it('should throw an error for an empty object', () => {
     const input = {};
-    expect(() => objectToQueryString(input)).toThrow();
+    expect(() => objectToQueryString(input)).toThrow(new Error("Invalid input format: Expected a non-empty object or a valid array format."));
   });
 
   it('should throw an error for an empty array', () => {
     const input: any[] = [];
-    expect(() => objectToQueryString(input)).toThrow();
+    expect(() => objectToQueryString(input)).toThrow(new Error("Invalid input format: Expected a non-empty object or a valid array format."));
   });
 });


### PR DESCRIPTION
Converts an object, array of key-value pairs (matrix), or a flat array of alternating keys and values into a URL query string.
The function can handle different input formats:
- A plain object (Record <string, any>),
- A matrix (an array of arrays, where each sub-array has two elements representing a key-value pair),
- A flat array with an even number of elements, where each even-indexed element is a key, and the following odd-indexed element is its corresponding value.